### PR TITLE
Change column separator to semicolon instead of comma

### DIFF
--- a/src/items-to-csv.xslt
+++ b/src/items-to-csv.xslt
@@ -7,7 +7,7 @@
 -->
     <xsl:output method="text" encoding="utf-8" />
 
-    <xsl:variable name="col_sep" select="','" />
+    <xsl:variable name="col_sep" select="';'" />
     <xsl:variable name="quote" select="''" />
 
     <xsl:template match="/items">


### PR DESCRIPTION
Address #7; a quick fix that might cause an issue if there are item names in the future that contain ";" but it's not a problem for now, as far as I am aware of.  

Uhh haven't tested that this works, actually, but should be fine?